### PR TITLE
Improve docs/setup for first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,20 @@ Answer King Python App
   - Follow installation documentation to configure Poetry for Windows https://python-poetry.org/docs/
 - #### node.js
   - Required by `pyright` package to detect and verify correct types have been used in the codebase
+
+- #### Docker
+  - Used to set up a disposable local MySQL database quickly.
+    - Install Docker following the docs [here](https://docs.docker.com/get-docker/).
+
 ***
 ### Installation:
 - Open root folder and run command `poetry install`
 - This will install a virtual environment to a path that looks like this `C:\Users\Username\AppData\Local\pypoetry\Cache\virtualenvs`. Alternatively, run command `poetry env info` or `poetry show -v`in the folder containing `pyproject.toml` and this will display where the virtual environment was installed
+
+### Setup
+- Add the required environment variables. The easiest ways to do this is with a .env file which can be provided by another member of the team.
+- Install the required MySQL container using `docker compose up -d`
+- Migrate the database using `poetry run python manage.py migrate`
 
 ### Run:
 - Run program using `poetry run python manage.py runserver`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Answer King Python App
   - Follow installation documentation to configure Poetry for Windows https://python-poetry.org/docs/
 - #### node.js
   - Required by `pyright` package to detect and verify correct types have been used in the codebase
-
 - #### Docker
   - Used to set up a disposable local MySQL database quickly.
     - Install Docker following the docs [here](https://docs.docker.com/get-docker/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.3'
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'answerking_app'
+      MYSQL_ROOT_PASSWORD: 'Admin123'
+    ports:
+      - '3306:3306'
+    expose:
+      - '3306'


### PR DESCRIPTION
When I was setting up the project locally I realised that their were a few steps missing. Mainly setting up MySQL and how to set up the environment variables.

I have tried to improve this by adding a docker-compose file to help the container be stood up with one command and a reference to the .env file and collecting that off a member of the team. 

I think as a further improvement it may be good to have a .env.development or something similar to be commited with the code. Something not sensitive but that will work. This can be discussed among the team for another PR however.