### PR TITLE
BENCH-238: Add freezetime to tests

### DIFF
--- a/answerking/settings/base.py
+++ b/answerking/settings/base.py
@@ -83,6 +83,7 @@ REST_FRAMEWORK = {
     ],
     "EXCEPTION_HANDLER": "answerking_app.utils.exceptions_handler.wrapper",
     "COERCE_DECIMAL_TO_STRING": False,
+    "DATETIME_FORMAT": "%Y-%m-%dT%H:%M:%S.%fZ",
 }
 
 # Database

--- a/answerking_app/tests/BaseTestClass.py
+++ b/answerking_app/tests/BaseTestClass.py
@@ -9,6 +9,7 @@ from answerking_app.utils.model_types import (
     OrderProductType,
     CategoryProductType,
 )
+from freezegun import freeze_time
 
 
 class TestBase(TransactionTestCase):
@@ -77,6 +78,7 @@ class TestBase(TransactionTestCase):
 
     time_format: str = "%Y-%m-%dT%H:%M:%S.%fZ"
 
+    @freeze_time("2022-11-28 13:00:00")
     def setUp(self):
         self.test_product_1: Product = Product.objects.create(
             name="Burger", price=1.20, description="desc"
@@ -125,18 +127,14 @@ class TestBase(TransactionTestCase):
 
     def assertUpdateTime(self, expected, actual, response, status_code):
         actual_time: datetime = self.convert_time(actual["lastUpdated"])
-        self.assertAlmostEqual(
-            expected["lastUpdated"], actual_time, delta=timedelta(seconds=2)
-        )
+        self.assertEqual(expected["lastUpdated"], actual_time)
         self.assertIsInstance(actual.pop("lastUpdated"), str)
         self.assertIsInstance(expected.pop("lastUpdated"), datetime)
         self.assertJSONResponse(expected, actual, response, status_code)
 
     def assertCreateUpdateTime(self, expected, actual, response, status_code):
         actual_time: datetime = self.convert_time(actual["createdOn"])
-        self.assertAlmostEqual(
-            expected["createdOn"], actual_time, delta=timedelta(seconds=2)
-        )
+        self.assertEqual(expected["createdOn"], actual_time)
         self.assertIsInstance(actual.pop("createdOn"), str)
         self.assertIsInstance(expected.pop("createdOn"), datetime)
         self.assertUpdateTime(expected, actual, response, status_code)

--- a/answerking_app/tests/BaseTestClass.py
+++ b/answerking_app/tests/BaseTestClass.py
@@ -139,7 +139,12 @@ class TestBase(TransactionTestCase):
         self.assertIsInstance(expected.pop("createdOn"), datetime)
         self.assertUpdateTime(expected, actual, response, status_code)
 
-    def convert_time(self, time_1):
+    def assertUpdateGreaterThanCreated(self, expected, actual):
+        expected_created: datetime = self.convert_time(expected["createdOn"])
+        self.assertTrue(actual["lastUpdated"] > actual["createdOn"])
+        self.assertTrue(expected["lastUpdated"] > expected_created)
+
+    def convert_time(self, time_1, *args):
         converted_time: datetime = datetime.strptime(time_1, self.time_format)
         return converted_time
 

--- a/answerking_app/tests/BaseTestClass.py
+++ b/answerking_app/tests/BaseTestClass.py
@@ -144,7 +144,7 @@ class TestBase(TransactionTestCase):
         self.assertTrue(actual["lastUpdated"] > actual["createdOn"])
         self.assertTrue(expected["lastUpdated"] > expected_created)
 
-    def convert_time(self, time_1, *args):
+    def convert_time(self, time_1):
         converted_time: datetime = datetime.strptime(time_1, self.time_format)
         return converted_time
 

--- a/answerking_app/tests/test_categories.py
+++ b/answerking_app/tests/test_categories.py
@@ -220,6 +220,7 @@ class CategoryTests(TestBase):
         # Assert
         self.assertNotEqual(old_category, actual)
         self.assertIn(updated_category, updated_list)
+        self.assertUpdateGreaterThanCreated(expected, actual)
         self.assertUpdateTime(expected, actual, response, 200)
 
     def test_put_invalid_id_returns_not_found(self):
@@ -354,6 +355,7 @@ class CategoryTests(TestBase):
         )
         actual = response.json()
 
+        self.assertUpdateGreaterThanCreated(expected, actual)
         self.assertUpdateTime(expected, actual, response, 200)
 
     def test_post_duplicated_name_returns_400(self):

--- a/answerking_app/tests/test_categories.py
+++ b/answerking_app/tests/test_categories.py
@@ -11,6 +11,8 @@ from answerking_app.utils.model_types import (
     CategoryProductType,
 )
 
+from freezegun import freeze_time
+
 client = Client()
 
 
@@ -76,6 +78,7 @@ class CategoryTests(TestBase):
             self.expected_invalid_url_parameters, actual, response, 400
         )
 
+    @freeze_time("2022-11-28 13:00:00")
     def test_post_valid_with_products_returns_ok(self):
         # Arrange
         old_list = client.get("/api/categories").json()
@@ -110,6 +113,7 @@ class CategoryTests(TestBase):
         self.assertIn(created_category, updated_list)
         self.assertCreateUpdateTime(expected, actual, response, 201)
 
+    @freeze_time("2022-11-28 13:00:00")
     def test_post_valid_without_products_returns_ok(self):
         # Arrange
         old_list = client.get("/api/categories").json()
@@ -141,6 +145,7 @@ class CategoryTests(TestBase):
         # Assert
         self.assertNotIn(actual, old_list)
         self.assertIn(created_product, updated_list)
+        # self.assertJSONResponse(expected, actual, response, 200)
         self.assertCreateUpdateTime(expected, actual, response, 201)
 
     def test_post_invalid_json_returns_bad_request(self):
@@ -178,6 +183,7 @@ class CategoryTests(TestBase):
         # Assert
         self.assertJSONErrorResponse(expected, actual, response, 400)
 
+    @freeze_time("2022-11-28 13:30:00")
     def test_put_valid_without_products_returns_no_products(self):
         # Arrange
         old_category = client.get(
@@ -319,6 +325,7 @@ class CategoryTests(TestBase):
             self.expected_invalid_url_parameters, actual, response, 400
         )
 
+    @freeze_time("2022-11-28 13:30:00")
     def test_put_add_duplicated_product_in_body_to_category_return_one(self):
         # Arrange
         product: CategoryProductType = self.get_mock_category_product_api(

--- a/answerking_app/tests/test_categories.py
+++ b/answerking_app/tests/test_categories.py
@@ -145,7 +145,6 @@ class CategoryTests(TestBase):
         # Assert
         self.assertNotIn(actual, old_list)
         self.assertIn(created_product, updated_list)
-        # self.assertJSONResponse(expected, actual, response, 200)
         self.assertCreateUpdateTime(expected, actual, response, 201)
 
     def test_post_invalid_json_returns_bad_request(self):

--- a/answerking_app/tests/test_orders.py
+++ b/answerking_app/tests/test_orders.py
@@ -240,6 +240,7 @@ class OrderTests(TestBase):
         self.assertIn(created_order, updated_orders_objects)
         self.assertNotIn(actual, old_orders_list_json)
         self.assertIn(actual, updated_orders_list_json)
+        self.assertUpdateGreaterThanCreated(expected, actual)
         self.assertUpdateTime(expected, actual, response, status_code=200)
 
     @freeze_time("2022-11-28 13:30:00")
@@ -273,6 +274,7 @@ class OrderTests(TestBase):
         self.assertIn(created_order, updated_orders_objects)
         self.assertNotIn(actual, old_orders_list_json)
         self.assertIn(actual, updated_orders_list_json)
+        self.assertUpdateGreaterThanCreated(expected, actual)
         self.assertUpdateTime(expected, actual, response, status_code=200)
         self.assertEqual(actual["lineItems"], [])
 

--- a/answerking_app/tests/test_orders.py
+++ b/answerking_app/tests/test_orders.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.db.models import QuerySet
 from django.test import Client
+from freezegun import freeze_time
 
 from answerking_app.models.models import Order, LineItem
 from answerking_app.tests.BaseTestClass import TestBase
@@ -64,6 +65,7 @@ class OrderTests(TestBase):
             self.expected_invalid_url_parameters, actual, response, 400
         )
 
+    @freeze_time("2022-11-28 13:00:00")
     def test_post_valid_without_products_returns_ok(self):
         # Arrange
         old_list = client.get("/api/orders").json()
@@ -94,6 +96,7 @@ class OrderTests(TestBase):
         self.assertEqual(len(created_order_products), 0)
         self.assertCreateUpdateTime(expected, actual, response, 201)
 
+    @freeze_time("2022-11-28 13:00:00")
     def test_post_valid_with_empty_products_returns_ok(self):
         # Arrange
         old_list = client.get("/api/orders").json()
@@ -125,6 +128,7 @@ class OrderTests(TestBase):
         self.assertEqual(len(created_order_products), 0)
         self.assertCreateUpdateTime(expected, actual, response, 201)
 
+    @freeze_time("2022-11-28 13:00:00")
     def test_post_valid_with_products_returns_ok(self):
         # Arrange
         old_orders_list_json = client.get("/api/orders").json()
@@ -206,6 +210,7 @@ class OrderTests(TestBase):
         # Assert
         self.assertJSONErrorResponse(expected, actual, response, 400)
 
+    @freeze_time("2022-11-28 13:30:00")
     def test_put_add_valid_products_to_order_return_ok(self):
         # Arrange
         old_orders_list_json = client.get("/api/orders").json()
@@ -237,6 +242,7 @@ class OrderTests(TestBase):
         self.assertIn(actual, updated_orders_list_json)
         self.assertUpdateTime(expected, actual, response, status_code=200)
 
+    @freeze_time("2022-11-28 13:30:00")
     def test_put_update_quantity_to_zero_return_empty_line_items(self):
         # Arrange
         old_orders_list_json = client.get("/api/orders").json()

--- a/poetry.lock
+++ b/poetry.lock
@@ -209,6 +209,17 @@ uritemplate = ">=3.0.0"
 validation = ["swagger-spec-validator (>=2.1.0)"]
 
 [[package]]
+name = "freezegun"
+version = "1.2.2"
+description = "Let your Python tests travel through time"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -347,6 +358,17 @@ all = ["twine (>=3.4.1)"]
 dev = ["twine (>=3.4.1)"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "0.21.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -420,6 +442,14 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-202
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "sqlparse"
 version = "0.4.3"
 description = "A non-validating SQL parser."
@@ -475,7 +505,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "52984e4b7c19ed3aaa4657f369fd3d11662f8ea8bcb8d83357daf3a8e2946135"
+content-hash = "738a40194b09c154ab353f9f52b0cb8cb17ee9db3836de09edcb834bb9d96ff2"
 
 [metadata.files]
 asgiref = [
@@ -602,6 +632,10 @@ drf-yasg = [
     {file = "drf-yasg-1.21.4.tar.gz", hash = "sha256:887c9f79e64f46aa48974234e61029b1bea6b12ea628a8fc8a3697589add1d3e"},
     {file = "drf_yasg-1.21.4-py3-none-any.whl", hash = "sha256:4a156d195fdccc51b40a227955588d982ca43c2e327927c7713bf967f5589913"},
 ]
+freezegun = [
+    {file = "freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
+    {file = "freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
+]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
@@ -701,6 +735,10 @@ pyright = [
     {file = "pyright-1.1.280-py3-none-any.whl", hash = "sha256:25917a14d873252c5c2e6fdbec322888c0480f6db95068ff6459befa9af3c92a"},
     {file = "pyright-1.1.280.tar.gz", hash = "sha256:4bcb167251419b3b736137b0535cb6bbfb5bef16eb74057eaf3ccaccb01d74c1"},
 ]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
 python-dotenv = [
     {file = "python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
     {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
@@ -755,6 +793,10 @@ ruamel-yaml-clib = [
 setuptools = [
     {file = "setuptools-65.5.1-py3-none-any.whl", hash = "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31"},
     {file = "setuptools-65.5.1.tar.gz", hash = "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 sqlparse = [
     {file = "sqlparse-0.4.3-py3-none-any.whl", hash = "sha256:0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ django-json-404-middleware = { git = "https://github.com/Axeltherabbit/django-js
 python-dotenv = "^0.21.0"
 drf-problems = { git = "https://github.com/Axeltherabbit/drf-problems" }
 typing-extensions = "^4.4.0"
+freezegun = "^1.2.2"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.10.0"


### PR DESCRIPTION
Added freeze_time to relevant category and order tests. Also edited the custom assert methods as they can now test for equality of times, as well as adding an assert method to check that the update time is later than created time for PUT tests.